### PR TITLE
fix: publishing of docker image to ghcr

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -16,6 +16,8 @@ const withMDX = mdx({
 });
 
 const nextConfig: NextConfig = {
+  // Enable standalone output for Docker builds
+  output: 'standalone',
   experimental: {
     turbo: {
       // ...


### PR DESCRIPTION
This pull request introduces a configuration change to facilitate Docker builds by enabling standalone output in the Next.js setup.

^ should fix broken image publish to ghcr: https://github.com/olyaiy/resume-lm/actions
