### PR TITLE
fix: resume score generateObject JSON mode + retries

### DIFF
--- a/src/utils/actions/resumes/actions.ts
+++ b/src/utils/actions/resumes/actions.ts
@@ -559,10 +559,17 @@ export async function generateResumeScore(
       `;
     }
 
+    // JSON mode + retries — some providers (e.g. OpenRouter) do not reliably
+    // use the tool path that default generateObject expects.
     const { object } = await generateObject({
       model: aiClient,
       schema: resumeScoreSchema,
-      prompt
+      mode: 'json',
+      schemaName: 'ResumeScore',
+      schemaDescription:
+        'Structured resume scoring: overallScore, completeness, impactScore, roleMatch, optional jobAlignment, miscellaneous metrics, improvements.',
+      prompt,
+      maxRetries: 2,
     });
 
     // console.log("THE OUTPUTTED object", object);


### PR DESCRIPTION
## Summary
Use \generateObject\ with \mode: 'json'\, schema name/description, and \maxRetries: 2\ so structured resume scoring works reliably on OpenRouter and other providers that do not use the default tool-calling path.

## Context
Relates to https://github.com/olyaiy/resume-lm/issues/12 (score / structured output failures).

## Testing
- \pnpm lint\ passes locally.

## Risk
Low — narrows object generation to JSON output with bounded retries; schema unchanged.
