### PR TITLE
fix: Supabase internal URL for server runtime (Docker-friendly)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,9 @@ OPENROUTER_API_KEY=
 # SUPABASE (Pre-configured for Docker)
 # ===========================================
 NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321
+# Optional: URL the Node server uses to reach Supabase when it differs from the browser URL
+# (e.g. app in Docker container, Supabase on host or another service name).
+# SUPABASE_INTERNAL_URL=http://host.docker.internal:54321
 NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJhbm9uIiwKICAgICJpc3MiOiAic3VwYWJhc2UtZGVtbyIsCiAgICAiaWF0IjogMTY0MTc2OTIwMCwKICAgICJleHAiOiAxNzk5NTM1NjAwCn0.dc_X5iR_VP_qT0zsiyj_I_OZ2T9FtRU2BBNWN8Bu4GE
 SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJzZXJ2aWNlX3JvbGUiLAogICAgImlzcyI6ICJzdXBhYmFzZS1kZW1vIiwKICAgICJpYXQiOiAxNjQxNzY5MjAwLAogICAgImV4cCI6IDE3OTk1MzU2MDAKfQ.DaYlNEoUrrEn2Ig7tqibS-PHK5vgusbcbo7X36XVt4Q
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ pnpm dev
 | **Supabase Studio** | http://localhost:54323 | Database dashboard |
 | **Redis Commander** | http://localhost:8081 | Redis management UI |
 
+If the Next.js app runs in a container but the browser uses a different host to reach Supabase, set **`SUPABASE_INTERNAL_URL`** in `.env.local` to the URL the **server** should use (for example `http://host.docker.internal:54321` or your Compose service name). When unset, the app uses `NEXT_PUBLIC_SUPABASE_URL` everywhere.
+
 > 📖 See [docker/DOCKER.md](docker/DOCKER.md) for full Docker documentation including full-stack mode.
 
 ## 📊 Database Architecture

--- a/src/utils/supabase/middleware.ts
+++ b/src/utils/supabase/middleware.ts
@@ -2,6 +2,13 @@ import { createServerClient } from '@supabase/ssr'
 import { NextResponse, type NextRequest } from 'next/server'
 import { getSubscriptionAccessState } from '@/lib/subscription-access'
 
+function getSupabaseUrl(): string {
+  return (
+    process.env.SUPABASE_INTERNAL_URL?.trim() ||
+    process.env.NEXT_PUBLIC_SUPABASE_URL!
+  )
+}
+
 // Routes available on the free plan (auth still required)
 const SUBSCRIPTION_EXEMPT_ROUTES = [
   '/home',
@@ -30,7 +37,7 @@ export async function updateSession(request: NextRequest) {
   })
 
   const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    getSupabaseUrl(),
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {

--- a/src/utils/supabase/server.ts
+++ b/src/utils/supabase/server.ts
@@ -1,11 +1,19 @@
 import { createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 
+/** Server-side Supabase API URL. Prefer SUPABASE_INTERNAL_URL in Docker or split host/network setups. */
+function getSupabaseUrl(): string {
+  return (
+    process.env.SUPABASE_INTERNAL_URL?.trim() ||
+    process.env.NEXT_PUBLIC_SUPABASE_URL!
+  )
+}
+
 export async function createClient() {
   const cookieStore = await cookies()
 
   return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    getSupabaseUrl(),
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       
@@ -32,7 +40,7 @@ export async function createClient() {
 
 export async function createServiceClient() {
   return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    getSupabaseUrl(),
     process.env.SUPABASE_SERVICE_ROLE_KEY!,
     {
       cookies: {


### PR DESCRIPTION
## Summary
Server Components, Route Handlers, and middleware now resolve the Supabase API URL as \SUPABASE_INTERNAL_URL\ (if set) **or** \NEXT_PUBLIC_SUPABASE_URL\.

## Why
In some Docker or split-network setups the browser reaches Supabase at one host while the Node server must use another (e.g. \host.docker.internal\ or a Compose service DNS name). Optional \SUPABASE_INTERNAL_URL\ avoids session/auth edge cases without changing the public URL the client uses.

## Docs
- \.env.example\ comment
- README Docker table section

## Testing
- \pnpm lint\ and \	sc --noEmit\ pass locally.


Made with [Cursor](https://cursor.com)